### PR TITLE
Don't overwrite existing data on initialization

### DIFF
--- a/mark-down.html
+++ b/mark-down.html
@@ -35,7 +35,7 @@ or alternatively:
        */
 
       ready: function() {
-        this.text = this.trim(this.textContent);
+        this.text = this.text || this.trim(this.textContent);
       },
       textChanged: function() {
         this.$.markdown.innerHTML = marked(this.text);


### PR DESCRIPTION
If you use `text="{{value}}"` instead of the text contents, this blows up. Using the `text` attribute is desirable if your Markdown content contains unescaped HTML, as an example.
